### PR TITLE
Break ties in adjacency matrix construction

### DIFF
--- a/layer.py
+++ b/layer.py
@@ -184,7 +184,7 @@ class graph_constructor(nn.Module):
         adj = F.relu(torch.tanh(self.alpha*a))
         mask = torch.zeros(idx.size(0), idx.size(0)).to(self.device)
         mask.fill_(float('0'))
-        s1,t1 = adj.topk(self.k,1)
+        s1,t1 = (adj + torch.rand_like(adj)*0.01).topk(self.k,1)
         mask.scatter_(1,t1,s1.fill_(1))
         adj = adj*mask
         return adj


### PR DESCRIPTION
This PR proposes a fix for the adjacency matrix construction.

I noticed that the learned adjacency matrices look unnatural, with most edges coming out of the first ~50% of the nodes (as per their arbitrary ID). See this example:
![adj_normal](https://user-images.githubusercontent.com/22178797/120200720-eade9900-c224-11eb-8084-2d4934b0fa10.png)


I have traced this issue back to the combination of `torch.topk` and `tanh`. The `tanh` squashing leads to many entries being (numerically) tied at the maximum possible value of `1.0`. In the case of ties, `torch.topk` always selects the **first** `K` tied entries. This leads to the issue in the image above. By adding just a tiny bit amount of random noise, this PR fixes this bias, leading to more "natural" adjacency matrices like this here:
 
![adj_tie_break](https://user-images.githubusercontent.com/22178797/120200728-eca85c80-c224-11eb-97ff-b2a36238aec4.png)
